### PR TITLE
fix: update all agentic workflows to use supported gpt-4-turbo model

### DIFF
--- a/.github/workflows/changelog-announcer.lock.yml
+++ b/.github/workflows/changelog-announcer.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c7d33d140c7c7306856b49a4697c0076043538ff639e894327f9d4cf85931c48","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot","agent_model":"gpt-4o-mini"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ae258b793f603cc526b2b93e750098bb10ffec850ae728d8c46f12b3ca3692e7","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot","agent_model":"gpt-4-turbo"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -74,7 +74,7 @@ name: "Helix AI Changelog Announcer"
   # - maintainer # Roles processed as role check in pre-activation job
   # - write # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "49 19 * * 6"
+  - cron: "9 23 * * 6"
     # Friendly format: weekly on saturday (scattered)
   workflow_dispatch:
     inputs:
@@ -120,7 +120,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: "gpt-4o-mini"
+          GH_AW_INFO_MODEL: "gpt-4-turbo"
           GH_AW_INFO_VERSION: "1.0.21"
           GH_AW_INFO_AGENT_VERSION: "1.0.21"
           GH_AW_INFO_CLI_VERSION: "v0.68.3"
@@ -193,14 +193,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_55c4b0c4ca214fbb_EOF'
+          cat << 'GH_AW_PROMPT_6329c298aaa5a23d_EOF'
           <system>
-          GH_AW_PROMPT_55c4b0c4ca214fbb_EOF
+          GH_AW_PROMPT_6329c298aaa5a23d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_55c4b0c4ca214fbb_EOF'
+          cat << 'GH_AW_PROMPT_6329c298aaa5a23d_EOF'
           <safe-output-tools>
           Tools: create_issue, create_discussion, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -232,12 +232,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_55c4b0c4ca214fbb_EOF
+          GH_AW_PROMPT_6329c298aaa5a23d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_55c4b0c4ca214fbb_EOF'
+          cat << 'GH_AW_PROMPT_6329c298aaa5a23d_EOF'
           </system>
           {{#runtime-import .github/workflows/changelog-announcer.md}}
-          GH_AW_PROMPT_55c4b0c4ca214fbb_EOF
+          GH_AW_PROMPT_6329c298aaa5a23d_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -409,9 +409,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_3f9390c62821a59a_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6db5997e06daf176_EOF'
           {"create_discussion":{"category":"announcements","fallback_to_issue":true,"max":1,"title_prefix":"🚀 Helix AI Changelog — "},"create_issue":{"labels":["report","automation","repo-management"],"max":1,"title_prefix":"[changelog-announcer] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_3f9390c62821a59a_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_6db5997e06daf176_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -633,7 +633,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_641f9e4f0375a38d_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_87171ba6f844964f_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -674,7 +674,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_641f9e4f0375a38d_EOF
+          GH_AW_MCP_CONFIG_87171ba6f844964f_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -724,7 +724,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: gpt-4o-mini
+          COPILOT_MODEL: gpt-4-turbo
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1146,7 +1146,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: gpt-4o-mini
+          COPILOT_MODEL: gpt-4-turbo
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.68.3
@@ -1228,7 +1228,7 @@ jobs:
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: "gpt-4o-mini"
+      GH_AW_ENGINE_MODEL: "gpt-4-turbo"
       GH_AW_WORKFLOW_ID: "changelog-announcer"
       GH_AW_WORKFLOW_NAME: "Helix AI Changelog Announcer"
     outputs:

--- a/.github/workflows/changelog-announcer.md
+++ b/.github/workflows/changelog-announcer.md
@@ -3,7 +3,7 @@ description: "Changelog announcer for Helix AI. Builds a polished changelog from
 
 engine:
   id: copilot
-  model: gpt-4o-mini
+  model: gpt-4-turbo
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deps-manager.lock.yml
+++ b/.github/workflows/deps-manager.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"63470f246cfb50362326da0c8c57b6910c4089badfa78100bf1a135ed870c961","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot","agent_model":"gpt-5.3-codex"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"735bfe95b82fc454720fac740d289b84666d151efd5d946aa7d004ea277d0903","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot","agent_model":"gpt-4-turbo"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -97,7 +97,7 @@ name: "Helix AI Dependency Manager"
   # - maintainer # Roles processed as role check in pre-activation job
   # - write # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "31 21 * * 3"
+  - cron: "27 23 * * 3"
     # Friendly format: weekly on wednesday (scattered)
   workflow_dispatch:
     inputs:
@@ -147,7 +147,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: "gpt-5.3-codex"
+          GH_AW_INFO_MODEL: "gpt-4-turbo"
           GH_AW_INFO_VERSION: "1.0.21"
           GH_AW_INFO_AGENT_VERSION: "1.0.21"
           GH_AW_INFO_CLI_VERSION: "v0.68.3"
@@ -231,19 +231,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_8674354f57133308_EOF'
+          cat << 'GH_AW_PROMPT_eee4de16faa5ee7a_EOF'
           <system>
-          GH_AW_PROMPT_8674354f57133308_EOF
+          GH_AW_PROMPT_eee4de16faa5ee7a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_8674354f57133308_EOF'
+          cat << 'GH_AW_PROMPT_eee4de16faa5ee7a_EOF'
           <safe-output-tools>
           Tools: add_comment(max:10), create_issue(max:2), close_pull_request(max:3), update_pull_request(max:5), create_pull_request_review_comment(max:10), submit_pull_request_review(max:5), add_labels(max:12), remove_labels(max:10), add_reviewer(max:5), push_to_pull_request_branch(max:3), missing_tool, missing_data, noop
-          GH_AW_PROMPT_8674354f57133308_EOF
+          GH_AW_PROMPT_eee4de16faa5ee7a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_8674354f57133308_EOF'
+          cat << 'GH_AW_PROMPT_eee4de16faa5ee7a_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -276,12 +276,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_8674354f57133308_EOF
+          GH_AW_PROMPT_eee4de16faa5ee7a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_8674354f57133308_EOF'
+          cat << 'GH_AW_PROMPT_eee4de16faa5ee7a_EOF'
           </system>
           {{#runtime-import .github/workflows/deps-manager.md}}
-          GH_AW_PROMPT_8674354f57133308_EOF
+          GH_AW_PROMPT_eee4de16faa5ee7a_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -462,9 +462,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_e328628a5a35d935_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_2804d7c5e3ae61ec_EOF'
           {"add_comment":{"hide_older_comments":true,"max":10,"target":"*"},"add_labels":{"allowed":["dependencies","auto-merge","actions-update","ansible-dependencies","terraform-dependencies","k8s-dependencies","kind:chore","kind:security","kind:release","kind:test","area:ci","area:github-actions","area:security","area:frontend","area:ui","area:db","area:cloudflare","area:kubernetes","area:ansible","area:terraform","area:observability","deployment","release","automation","priority:critical","priority:high","priority:medium","priority:low","status:blocked","status:needs-info","status:ready","status:in-progress","status:backlog"],"blocked":["~*","*[bot]","security-reviewed","approved","merged","do-not-merge"],"max":12,"target":"*"},"add_reviewer":{"allowed":["Sinless777","copilot"],"max":5,"target":"*"},"close_pull_request":{"max":3,"required_labels":["dependencies"],"target":"*"},"create_issue":{"labels":["report","automation","dependencies"],"max":2,"title_prefix":"[deps-manager] "},"create_pull_request_review_comment":{"max":10,"side":"RIGHT","target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_to_pull_request_branch":{"allowed_files":["package.json","pnpm-lock.yaml","pnpm-workspace.yaml","**/package.json","**/Dockerfile","**/Dockerfile.*","Dockerfile","docker/**","Kubernetes/**","kubernetes/**","Ansible/**","ansible/**","Terraform/**","terraform/**",".github/dependabot.yaml",".github/dependabot.yml",".github/renovate.json5","renovate.json","renovate.json5"],"if_no_changes":"ignore","labels":["dependencies"],"max":3,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_files_policy":"fallback-to-issue","protected_path_prefixes":[".github/",".agents/"],"target":"*"},"remove_labels":{"allowed":["auto-merge","status:blocked","status:needs-info","status:ready","status:in-progress","status:backlog","priority:critical","priority:high","priority:medium","priority:low"],"max":10,"target":"*"},"report_incomplete":{},"submit_pull_request_review":{"allowed_events":["COMMENT","APPROVE","REQUEST_CHANGES"],"max":5,"target":"*"},"update_pull_request":{"allow_body":true,"allow_title":true,"max":5,"target":"*"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_e328628a5a35d935_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_2804d7c5e3ae61ec_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -874,7 +874,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_dbbacad9b6ba7137_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_b7d1d085b7b1f4e4_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -915,7 +915,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_dbbacad9b6ba7137_EOF
+          GH_AW_MCP_CONFIG_b7d1d085b7b1f4e4_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -974,7 +974,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: gpt-5.3-codex
+          COPILOT_MODEL: gpt-4-turbo
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1397,7 +1397,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: gpt-5.3-codex
+          COPILOT_MODEL: gpt-4-turbo
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.68.3
@@ -1480,7 +1480,7 @@ jobs:
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: "gpt-5.3-codex"
+      GH_AW_ENGINE_MODEL: "gpt-4-turbo"
       GH_AW_WORKFLOW_ID: "deps-manager"
       GH_AW_WORKFLOW_NAME: "Helix AI Dependency Manager"
     outputs:

--- a/.github/workflows/deps-manager.md
+++ b/.github/workflows/deps-manager.md
@@ -3,7 +3,7 @@ description: "Dependency manager for Helix AI. Reviews dependency issues and pul
 
 engine:
   id: copilot
-  model: gpt-5.3-codex
+  model: gpt-4-turbo
 
 on:
   workflow_dispatch:

--- a/.github/workflows/package-manager.lock.yml
+++ b/.github/workflows/package-manager.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"bf5fcb49e5367eaa09b7c385327a98957d96067a3455ff1d6ab04abc2bd93bb1","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot","agent_model":"gpt-5.3-codex"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9a39841efdae2fab7becf0ad039eba9ca854d90620b154a212c83e55e3322b03","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot","agent_model":"gpt-4-turbo"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -84,7 +84,7 @@ name: "Helix AI Package Manager"
   # - maintainer # Roles processed as role check in pre-activation job
   # - write # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "37 22 * * 2"
+  - cron: "17 22 * * 2"
     # Friendly format: weekly on tuesday (scattered)
   workflow_dispatch:
     inputs:
@@ -135,7 +135,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: "gpt-5.3-codex"
+          GH_AW_INFO_MODEL: "gpt-4-turbo"
           GH_AW_INFO_VERSION: "1.0.21"
           GH_AW_INFO_AGENT_VERSION: "1.0.21"
           GH_AW_INFO_CLI_VERSION: "v0.68.3"
@@ -219,19 +219,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_c5c385041602f526_EOF'
+          cat << 'GH_AW_PROMPT_c9fdea8cf6974f98_EOF'
           <system>
-          GH_AW_PROMPT_c5c385041602f526_EOF
+          GH_AW_PROMPT_c9fdea8cf6974f98_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c5c385041602f526_EOF'
+          cat << 'GH_AW_PROMPT_c9fdea8cf6974f98_EOF'
           <safe-output-tools>
           Tools: add_comment, create_issue, create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_c5c385041602f526_EOF
+          GH_AW_PROMPT_c9fdea8cf6974f98_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_c5c385041602f526_EOF'
+          cat << 'GH_AW_PROMPT_c9fdea8cf6974f98_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -261,12 +261,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_c5c385041602f526_EOF
+          GH_AW_PROMPT_c9fdea8cf6974f98_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c5c385041602f526_EOF'
+          cat << 'GH_AW_PROMPT_c9fdea8cf6974f98_EOF'
           </system>
           {{#runtime-import .github/workflows/package-manager.md}}
-          GH_AW_PROMPT_c5c385041602f526_EOF
+          GH_AW_PROMPT_c9fdea8cf6974f98_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -438,9 +438,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8bd223b9dd74883a_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_7708ee3569169ae7_EOF'
           {"add_comment":{"max":1},"create_issue":{"labels":["report","automation","package-management"],"max":1,"title_prefix":"[package-manager] "},"create_pull_request":{"labels":["automation","package-management"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[package-manager] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_8bd223b9dd74883a_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_7708ee3569169ae7_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -695,7 +695,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_043eb155f6438edd_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_d4189254e75134ed_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -736,7 +736,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_043eb155f6438edd_EOF
+          GH_AW_MCP_CONFIG_d4189254e75134ed_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -799,7 +799,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: gpt-5.3-codex
+          COPILOT_MODEL: gpt-4-turbo
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1222,7 +1222,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: gpt-5.3-codex
+          COPILOT_MODEL: gpt-4-turbo
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.68.3
@@ -1306,7 +1306,7 @@ jobs:
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: "gpt-5.3-codex"
+      GH_AW_ENGINE_MODEL: "gpt-4-turbo"
       GH_AW_WORKFLOW_ID: "package-manager"
       GH_AW_WORKFLOW_NAME: "Helix AI Package Manager"
     outputs:

--- a/.github/workflows/package-manager.md
+++ b/.github/workflows/package-manager.md
@@ -3,7 +3,7 @@ description: "Package manager agent for Helix AI. Audits and maintains release, 
 
 engine:
   id: copilot
-  model: gpt-5.3-codex
+  model: gpt-4-turbo
 
 on:
   workflow_dispatch:

--- a/.github/workflows/repo-manager.lock.yml
+++ b/.github/workflows/repo-manager.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7a4b899c2deb23ef17e3d9985701c2ef4194f23a863235772c8056543dcb78ea","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot","agent_model":"gpt-5.3-codex"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"772a74e3889b7732abbbbbb4cc4a9dcb299ca54fe44b9ddf8d5551dfbec388d1","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot","agent_model":"gpt-4-turbo"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -87,7 +87,7 @@ name: "Helix AI Repo Manager"
   # - maintainer # Roles processed as role check in pre-activation job
   # - write # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "15 23 * * 1"
+  - cron: "43 4 * * 1"
     # Friendly format: weekly on monday (scattered)
   workflow_dispatch:
     inputs:
@@ -137,7 +137,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: "gpt-5.3-codex"
+          GH_AW_INFO_MODEL: "gpt-4-turbo"
           GH_AW_INFO_VERSION: "1.0.21"
           GH_AW_INFO_AGENT_VERSION: "1.0.21"
           GH_AW_INFO_CLI_VERSION: "v0.68.3"
@@ -221,14 +221,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_008c99d88826c61a_EOF'
+          cat << 'GH_AW_PROMPT_0111a079c3513769_EOF'
           <system>
-          GH_AW_PROMPT_008c99d88826c61a_EOF
+          GH_AW_PROMPT_0111a079c3513769_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_008c99d88826c61a_EOF'
+          cat << 'GH_AW_PROMPT_0111a079c3513769_EOF'
           <safe-output-tools>
           Tools: add_comment(max:5), create_issue(max:3), update_issue, update_pull_request, add_labels(max:12), remove_labels(max:6), assign_milestone(max:5), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -260,12 +260,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_008c99d88826c61a_EOF
+          GH_AW_PROMPT_0111a079c3513769_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_008c99d88826c61a_EOF'
+          cat << 'GH_AW_PROMPT_0111a079c3513769_EOF'
           </system>
           {{#runtime-import .github/workflows/repo-manager.md}}
-          GH_AW_PROMPT_008c99d88826c61a_EOF
+          GH_AW_PROMPT_0111a079c3513769_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -436,9 +436,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_bd44d13ce192c151_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_1cf3ae3712acd4cd_EOF'
           {"add_comment":{"hide_older_comments":true,"max":5,"target":"*"},"add_labels":{"allowed":["area:frontend","area:e2e","area:integrations","area:services","area:ui","area:config","area:db","area:flags","area:libs","area:github-actions","area:cloudflare","area:docs","area:kubernetes","area:ansible","area:terraform","area:security","area:observability","area:ci","kind:bug","kind:feature","kind:chore","kind:refactor","kind:security","kind:documentation","kind:test","kind:release","priority:critical","priority:high","priority:medium","priority:low","status:blocked","status:needs-info","status:ready","status:backlog","status:in-progress","automation","agentic-workflow","repo-management","report","cloudflare","deployment","release","dependencies"],"blocked":["~*","*[bot]","security-reviewed","approved","merged","do-not-merge"],"max":12,"target":"*"},"assign_milestone":{"allowed":["Backlog","MVP","Frontend","Cloudflare Setup","Infrastructure","Security","Observability","Agentic Workflows","Documentation","Release","CI/CD"],"max":5},"create_issue":{"labels":["report","automation","repo-management"],"max":3,"title_prefix":"[repo-manager] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"remove_labels":{"allowed":["status:needs-info","status:ready","status:backlog","status:blocked","status:in-progress","priority:low","priority:medium","priority:high","priority:critical"],"max":6,"target":"*"},"report_incomplete":{},"update_issue":{"allow_body":true,"footer":true,"max":1,"target":"*"},"update_pull_request":{"allow_body":true,"allow_title":true,"footer":true,"max":1,"target":"*"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_bd44d13ce192c151_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_1cf3ae3712acd4cd_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -803,7 +803,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_89f97efdd3986416_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_40a46ef35af1637a_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -844,7 +844,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_89f97efdd3986416_EOF
+          GH_AW_MCP_CONFIG_40a46ef35af1637a_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -897,7 +897,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: gpt-5.3-codex
+          COPILOT_MODEL: gpt-4-turbo
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1318,7 +1318,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: gpt-5.3-codex
+          COPILOT_MODEL: gpt-4-turbo
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.68.3
@@ -1401,7 +1401,7 @@ jobs:
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: "gpt-5.3-codex"
+      GH_AW_ENGINE_MODEL: "gpt-4-turbo"
       GH_AW_WORKFLOW_ID: "repo-manager"
       GH_AW_WORKFLOW_NAME: "Helix AI Repo Manager"
     outputs:

--- a/.github/workflows/repo-manager.md
+++ b/.github/workflows/repo-manager.md
@@ -3,7 +3,7 @@ description: "Repo manager agent for Helix AI. Intelligently triages issues and 
 
 engine:
   id: copilot
-  model: gpt-5.3-codex
+  model: gpt-4-turbo
 
 on:
   workflow_dispatch:

--- a/.github/workflows/reviewer-ipr-manager.lock.yml
+++ b/.github/workflows/reviewer-ipr-manager.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"123ee098ab2cb1c24ae3579a1913529a342ab2dd31e720cbe7fcfcbf1db8dcae","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot","agent_model":"gpt-5.3-codex"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b097722ee9b93158c8f41b26f730160c252f84b1f4c49ce3ebb0333635e71eaf","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot","agent_model":"gpt-4-turbo"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -84,7 +84,7 @@ name: "Helix AI Reviewer IPR Manager"
   # - maintainer # Roles processed as role check in pre-activation job
   # - write # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "23 2 * * 5"
+  - cron: "51 10 * * 5"
     # Friendly format: weekly on friday (scattered)
   workflow_dispatch:
     inputs:
@@ -134,7 +134,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: "gpt-5.3-codex"
+          GH_AW_INFO_MODEL: "gpt-4-turbo"
           GH_AW_INFO_VERSION: "1.0.21"
           GH_AW_INFO_AGENT_VERSION: "1.0.21"
           GH_AW_INFO_CLI_VERSION: "v0.68.3"
@@ -218,14 +218,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_600509ad885fafb6_EOF'
+          cat << 'GH_AW_PROMPT_152ec0a66a0b23fa_EOF'
           <system>
-          GH_AW_PROMPT_600509ad885fafb6_EOF
+          GH_AW_PROMPT_152ec0a66a0b23fa_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_600509ad885fafb6_EOF'
+          cat << 'GH_AW_PROMPT_152ec0a66a0b23fa_EOF'
           <safe-output-tools>
           Tools: add_comment(max:10), create_issue(max:2), close_issue(max:5), close_pull_request(max:5), add_labels(max:10), remove_labels(max:10), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -257,12 +257,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_600509ad885fafb6_EOF
+          GH_AW_PROMPT_152ec0a66a0b23fa_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_600509ad885fafb6_EOF'
+          cat << 'GH_AW_PROMPT_152ec0a66a0b23fa_EOF'
           </system>
           {{#runtime-import .github/workflows/reviewer-ipr-manager.md}}
-          GH_AW_PROMPT_600509ad885fafb6_EOF
+          GH_AW_PROMPT_152ec0a66a0b23fa_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -433,9 +433,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_04e3fe6f5fc27244_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_fe49c6da9683de3b_EOF'
           {"add_comment":{"hide_older_comments":true,"max":10,"target":"*"},"add_labels":{"allowed":["status:stale","stale","status:needs-info","status:blocked","status:ready","status:backlog","status:in-progress","priority:critical","priority:high","priority:medium","priority:low","kind:bug","kind:feature","kind:chore","kind:refactor","kind:security","kind:documentation","kind:test","kind:release","area:frontend","area:e2e","area:integrations","area:services","area:ui","area:config","area:db","area:flags","area:libs","area:github-actions","area:cloudflare","area:docs","area:kubernetes","area:ansible","area:terraform","area:security","area:observability","area:ci","automation","repo-management","agentic-workflow","dependencies","release","deployment","cloudflare"],"blocked":["~*","*[bot]","security-reviewed","approved","merged"],"max":10,"target":"*"},"close_issue":{"max":5,"required_labels":["status:stale","stale"],"target":"*"},"close_pull_request":{"max":5},"create_issue":{"labels":["report","automation","repo-management"],"max":2,"title_prefix":"[reviewer-ipr-manager] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"remove_labels":{"allowed":["status:stale","stale","status:needs-info","status:blocked","status:ready","status:backlog","status:in-progress","priority:critical","priority:high","priority:medium","priority:low"],"max":10,"target":"*"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_04e3fe6f5fc27244_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_fe49c6da9683de3b_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -731,7 +731,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_b0e1a61e82609ae1_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_7531f31d3480930e_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -772,7 +772,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_b0e1a61e82609ae1_EOF
+          GH_AW_MCP_CONFIG_7531f31d3480930e_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -822,7 +822,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: gpt-5.3-codex
+          COPILOT_MODEL: gpt-4-turbo
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1243,7 +1243,7 @@ jobs:
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: gpt-5.3-codex
+          COPILOT_MODEL: gpt-4-turbo
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.68.3
@@ -1326,7 +1326,7 @@ jobs:
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: "gpt-5.3-codex"
+      GH_AW_ENGINE_MODEL: "gpt-4-turbo"
       GH_AW_WORKFLOW_ID: "reviewer-ipr-manager"
       GH_AW_WORKFLOW_NAME: "Helix AI Reviewer IPR Manager"
     outputs:

--- a/.github/workflows/reviewer-ipr-manager.md
+++ b/.github/workflows/reviewer-ipr-manager.md
@@ -3,7 +3,7 @@ description: "Reviewer IPR manager for Helix AI. Reviews open issues and pull re
 
 engine:
   id: copilot
-  model: gpt-5.3-codex
+  model: gpt-4-turbo
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
- changelog-announcer: gpt-4o-mini → gpt-4-turbo
- repo-manager: gpt-5.3-codex → gpt-4-turbo
- reviewer-ipr-manager: gpt-5.3-codex → gpt-4-turbo
- deps-manager: gpt-5.3-codex → gpt-4-turbo
- package-manager: gpt-5.3-codex → gpt-4-turbo

All workflows previously failed with 'CAPIError: 400 The requested model is not supported'. The subscription tier only supports gpt-4-turbo and similar models. All 5 workflows now compile successfully.