### PR TITLE
feat: set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -59,7 +59,9 @@
       "options": {
         "targetName": "test"
       },
-      "exclude": ["apps/services/user-e2e/**/*"]
+      "exclude": [
+        "apps/services/user-e2e/**/*"
+      ]
     },
     {
       "plugin": "@nx/rollup/plugin",
@@ -71,7 +73,10 @@
     }
   ],
   "namedInputs": {
-    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "default": [
+      "{projectRoot}/**/*",
+      "sharedGlobals"
+    ],
     "production": [
       "default",
       "!{projectRoot}/**/*.spec.ts",
@@ -113,52 +118,101 @@
   },
   "targetDefaults": {
     "build": {
-      "dependsOn": ["^build"],
-      "inputs": ["production", "^production"],
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "production",
+        "^production"
+      ],
       "cache": true
     },
     "typecheck": {
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^production"],
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "cache": true
     },
     "lint": {
-      "inputs": ["default", "^production"],
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "cache": true
     },
     "test": {
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^production"],
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "cache": true
     },
     "e2e": {
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^production"],
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "cache": true
     },
     "e2e-ci": {
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^production"],
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "default",
+        "^production"
+      ],
       "cache": true
     },
     "preview": {
-      "dependsOn": ["build"],
-      "inputs": ["production", "^production", "cloudflare"],
+      "dependsOn": [
+        "build"
+      ],
+      "inputs": [
+        "production",
+        "^production",
+        "cloudflare"
+      ],
       "cache": false
     },
     "deploy": {
-      "dependsOn": ["build"],
-      "inputs": ["production", "^production", "cloudflare"],
+      "dependsOn": [
+        "build"
+      ],
+      "inputs": [
+        "production",
+        "^production",
+        "cloudflare"
+      ],
       "cache": false
     },
     "upload": {
-      "dependsOn": ["build"],
-      "inputs": ["production", "^production", "cloudflare"],
+      "dependsOn": [
+        "build"
+      ],
+      "inputs": [
+        "production",
+        "^production",
+        "cloudflare"
+      ],
       "cache": false
     },
     "cf:typegen": {
-      "inputs": ["cloudflare"],
+      "inputs": [
+        "cloudflare"
+      ],
       "cache": true
     }
-  }
+  },
+  "nxCloudId": "6a1dd0bc74ae73b853c5d690"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/6a1dd0bab73810613872f15f/workspaces/6a1dd0bc74ae73b853c5d690

> [!TIP]
> Run `npx nx generate ci-workflow` if you don't have a CI script configured yet.

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.