### PR TITLE
fix(frontend): resolve UI import alias and harden lint command

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -22,7 +22,7 @@
     "cf:deploy": "cross-env NODE_ENV=production NEXT_PRIVATE_MINIMAL_MODE=1 opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "cf:upload": "cross-env NODE_ENV=production NEXT_PRIVATE_MINIMAL_MODE=1 opennextjs-cloudflare build && opennextjs-cloudflare upload",
     "cf:typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",
-    "lint": "eslint --no-warn-ignored . --ignore-pattern next-env.d.ts --ignore-pattern cloudflare-env.d.ts --ignore-pattern open-next-env.d.ts --ignore-pattern .next/** --ignore-pattern .open-next/**"
+    "lint": "eslint --no-error-on-unmatched-pattern --no-warn-ignored . --ignore-pattern next-env.d.ts --ignore-pattern cloudflare-env.d.ts --ignore-pattern open-next-env.d.ts --ignore-pattern .next/** --ignore-pattern .open-next/**"
   },
   "dependencies": {
     "@emotion/react": "11.14.0",

--- a/apps/frontend/project.json
+++ b/apps/frontend/project.json
@@ -91,7 +91,7 @@
       "outputs": ["{options.outputFile}"],
       "options": {
         "cwd": "apps/frontend",
-        "command": "eslint . --ignore-pattern next-env.d.ts --ignore-pattern cloudflare-env.d.ts --ignore-pattern open-next-env.d.ts --ignore-pattern .next/** --ignore-pattern .open-next/**"
+        "command": "eslint --no-error-on-unmatched-pattern --no-warn-ignored . --ignore-pattern next-env.d.ts --ignore-pattern cloudflare-env.d.ts --ignore-pattern open-next-env.d.ts --ignore-pattern .next/** --ignore-pattern .open-next/**"
       },
       "metadata": {
         "technologies": ["eslint"],

--- a/apps/frontend/src/app/About/page.tsx
+++ b/apps/frontend/src/app/About/page.tsx
@@ -9,7 +9,7 @@ import { AboutContent } from "../../content/about";
 import { headerProps } from "../../content/header";
 
 const Header = dynamic(
-  () => import("@aerealith-ai/ui").then((module) => module.Header),
+  () => import("@helix-ai/ui").then((module) => module.Header),
   { ssr: false },
 );
 

--- a/apps/frontend/src/app/Contact/page.tsx
+++ b/apps/frontend/src/app/Contact/page.tsx
@@ -9,7 +9,7 @@ import { CONTACT_OPTIONS } from "../../content/contact";
 import { headerProps } from "../../content/header";
 
 const Header = dynamic(
-  () => import("@aerealith-ai/ui").then((module) => module.Header),
+  () => import("@helix-ai/ui").then((module) => module.Header),
   { ssr: false },
 );
 

--- a/apps/frontend/src/app/technology/[link]/page.tsx
+++ b/apps/frontend/src/app/technology/[link]/page.tsx
@@ -10,7 +10,7 @@ import { headerProps } from "../../../content/header";
 import * as technology from "../../../content/technology";
 
 const Header = dynamic(
-  () => import("@aerealith-ai/ui").then((module) => module.Header),
+  () => import("@helix-ai/ui").then((module) => module.Header),
   { ssr: false },
 );
 

--- a/apps/frontend/src/app/technology/page.tsx
+++ b/apps/frontend/src/app/technology/page.tsx
@@ -39,7 +39,7 @@ type LooseTechnologyCard = {
 };
 
 const Header = dynamic(
-  () => import("@aerealith-ai/ui").then((module) => module.Header),
+  () => import("@helix-ai/ui").then((module) => module.Header),
   { ssr: false },
 );
 


### PR DESCRIPTION
### Motivation
- Next.js type checking failed to resolve the UI package because pages imported `@aerealith-ai/ui` while the workspace alias is `@helix-ai/ui`, causing the production build to fail.
- ESLint invocations were failing when Next.js generated `.next` artifacts were present because the lint command didn't tolerate ignored or unmatched glob patterns.

### Description
- Replaced dynamic imports of the `Header` component from `@aerealith-ai/ui` to the workspace alias `@helix-ai/ui` in `apps/frontend/src/app/About/page.tsx`, `apps/frontend/src/app/Contact/page.tsx`, `apps/frontend/src/app/technology/page.tsx`, and `apps/frontend/src/app/technology/[link]/page.tsx` so the UI package can be resolved by the build/type checker.
- Updated the frontend lint command in `apps/frontend/package.json` and the `lint` target in `apps/frontend/project.json` to add `--no-error-on-unmatched-pattern --no-warn-ignored` so ESLint will not fail on ignored/generated Next.js output.
- Ran `prettier` on modified files to normalize formatting.

### Testing
- Ran `pnpm nx build frontend`, which completed successfully after the fixes (Next.js build succeeded and pages were generated).
- Ran `pnpm nx lint frontend`, which completed successfully after relaxing the lint flags.
- Ran `pnpm exec prettier --write` on the changed files to format them, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25dd9cbc508328a04cd315cd1639b3)